### PR TITLE
[Eigen] Add alternative site assocation path.

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var path = require('path');
 var fs = require('fs');
 var app = express();
 app.use(morgan('combined'));
-app.use('/apple-app-site-association', artsyEigenWebAssociation);
+app.use('/(.well-known/)?apple-app-site-association', artsyEigenWebAssociation);
 app.use(function(req, res, next) {
   res.setHeader('Strict-Transport-Security', 'max-age=0');
   res.redirect(301, 'https://www.artsy.net' + req.url);


### PR DESCRIPTION
I _think_ this is correct, as per [the Express docs](http://expressjs.com/en/api.html#app.mountpath), but this app isn’t really easily testable locally, so please review properly.