### PR TITLE
#migration drop ELB servcice.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -79,44 +79,6 @@ metadata:
     app: artsy-wwwify
     component: web
     layer: application
-  name: artsy-wwwify-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "5"
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      name: http
-      targetPort: wwwify-http
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: wwwify-http
-  selector:
-    app: artsy-wwwify
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-{%- for cidr_block in cloudflareIpSourceRanges %}
-    - {{ cidr_block }}
-{%- endfor %}
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: artsy-wwwify
-    component: web
-    layer: application
   name: artsy-wwwify-web-internal
   namespace: default
 spec:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -79,44 +79,6 @@ metadata:
     app: artsy-wwwify
     component: web
     layer: application
-  name: artsy-wwwify-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "5"
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      name: http
-      targetPort: wwwify-http
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: wwwify-http
-  selector:
-    app: artsy-wwwify
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-{%- for cidr_block in cloudflareIpSourceRanges %}
-    - {{ cidr_block }}
-{%- endfor %}
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: artsy-wwwify
-    component: web
-    layer: application
   name: artsy-wwwify-web-internal
   namespace: default
 spec:


### PR DESCRIPTION
Follow-up to https://github.com/artsy/artsy-wwwify/pull/44

DNS artsy.net were updated to point to Prod Ingress Controllers. DNS artsy-wwwify.artsy.net was created to point to Staging Ingress Controllers. They were done at 7/28 6pm ET. TTL is Auto which is 5 minutes.

I have waited the TTL and confirmed app working using `curl`.

Migration
---
1. Merge and deploy this PR
2. Delete the "artsy-wwwify-web" service
Staging:https://kubernetes-staging.artsy.net/#!/service/default/artsy-wwwify?namespace=default
Production: https://kubernetes.artsy.net/#!/service/default/artsy-wwwify?namespace=default
See docs in https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 section Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service