### PR TITLE
Also redirect from m.artsy.net and ascii.artsy.net #migration

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -109,4 +109,17 @@ spec:
             backend:
               serviceName: artsy-wwwify-web-internal
               servicePort: http
-
+    - host: m.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: artsy-wwwify-web-internal
+              servicePort: http
+    - host: ascii.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: artsy-wwwify-web-internal
+              servicePort: http


### PR DESCRIPTION
The Ohm PR reminded me that wwwify probably needs to respond for additional hostnames as well, since it was where we pointed old names that are no longer serviced. `m.artsy.net` hosted the mobile site for a long time so there may be links to it out in the wild. I'm not sure what links to ascii.artsy.net, but according to DNS it was also pointing at this app's former load-balancer.

### Migration

Once this is deployed, DNS for m.artsy.net and ascii.artsy.net should be updated to the production network load-balancer. (There aren't staging versions of either of these names.)