### PR TITLE
fix: return android assetlinks.json file as a json instead of text

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@ var path = require('path');
 var artsyEigenWebAssociation = require('artsy-eigen-web-association');
 var iosVerificationFileName = path.resolve(__dirname, 'apple-developer-domain-association.txt');
 var androidVerificationFileName = path.resolve(__dirname, 'assetlinks.json');
-var options = { 'headers': { 'Content-Type': 'text/plain' } };
 
 var express = require('express');
 var http = require('http');
@@ -12,7 +11,7 @@ app.use(morgan('combined'));
 app.use('/(.well-known/)?apple-app-site-association', artsyEigenWebAssociation);
 
 app.get('/.well-known/apple-developer-domain-association.txt', function (req, res) {
-  res.sendFile(iosVerificationFileName, options, function (error) {
+  res.sendFile(iosVerificationFileName, { 'headers': { 'Content-Type': 'text/plain' } }, function (error) {
     if (error) {
       console.log(error);
       code = error.status >= 100 && error.status < 600 ? error.status : 500
@@ -22,7 +21,7 @@ app.get('/.well-known/apple-developer-domain-association.txt', function (req, re
 })
 
 app.get('/.well-known/assetlinks.json', function (req, res) {
-  res.sendFile(androidVerificationFileName, options, function (error) {
+  res.sendFile(androidVerificationFileName, { 'headers': { 'Content-Type': 'application/json' } }, function (error) {
     if (error) {
       console.log(error);
       code = error.status >= 100 && error.status < 600 ? error.status : 500

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -38,8 +38,9 @@ describe('artsy-wwwify', () => {
 
   it('serves Android assetlinks file at root', async () => {
     const res = await request(app).get('/.well-known/assetlinks.json');
-    console.log(res)
     expect(res.statusCode).toEqual(200);
-    expect(res.text).toContain('net.artsy.app');
+    expect(res.headers["content-type"]).toEqual('application/json');
+    expect(res.body[0].target.package_name).toEqual('net.artsy.app');
+    expect(res.body[0].target.namespace).toEqual('android_app');
   });
 });


### PR DESCRIPTION
We changed the way we return the assetLinks file to be returned as a json instead of a text as Google is requiring. See docs here: https://developer.android.com/training/app-links/verify-site-associations#publish-json