### PR TITLE
chore: update apple-app-association

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/artsy/artsy-wwwify",
   "dependencies": {
-    "artsy-eigen-web-association": "git://github.com/artsy/artsy-eigen-web-association.git",
+    "@artsy/eigen-web-association": "git://github.com/artsy/artsy-eigen-web-association.git",
     "morgan": "1.10.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var artsyEigenWebAssociation = require('artsy-eigen-web-association');
+var artsyEigenWebAssociation = require('@artsy/eigen-web-association');
 var iosVerificationFileName = path.resolve(__dirname, 'apple-developer-domain-association.txt');
 var androidVerificationFileName = path.resolve(__dirname, 'assetlinks.json');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@artsy/eigen-web-association@git://github.com/artsy/artsy-eigen-web-association.git":
+  version "1.2.1"
+  resolved "git://github.com/artsy/artsy-eigen-web-association.git#0589e3d9da9b904a51d4b8c9c39cd8a585428493"
+  dependencies:
+    express "^4.15.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -484,12 +490,6 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
-
-"artsy-eigen-web-association@git://github.com/artsy/artsy-eigen-web-association.git":
-  version "1.0.7"
-  resolved "git://github.com/artsy/artsy-eigen-web-association.git#300293aa524984efe82768b2cbbd70b15d8a4dd1"
-  dependencies:
-    express "*"
 
 asn1@~0.2.3:
   version "0.2.4"
@@ -1156,7 +1156,7 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
-express@*:
+express@^4.15.0:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==


### PR DESCRIPTION
**Description:**
This update is intended to:
-  Ignore the **price-database** link from deeplinks on iOS.
-  Use `@artsy/eigen-web-association` instead of `artsy-eigen-web-association` as a dependency

**Note:** I tested my changes locally
<img width="1314" alt="Screenshot 2021-11-09 at 15 09 12" src="https://user-images.githubusercontent.com/11945712/140939359-0c196111-0399-472a-899e-b27fdaa6df7b.png">

