### PR TITLE
fix: change how eigen-web-association dep is declared

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/artsy/artsy-wwwify",
   "dependencies": {
-    "@artsy/eigen-web-association": "git://github.com/artsy/artsy-eigen-web-association.git",
+    "@artsy/eigen-web-association": "^1.2.1",
     "morgan": "1.10.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,10 @@
 # yarn lockfile v1
 
 
-"@artsy/eigen-web-association@git://github.com/artsy/artsy-eigen-web-association.git":
+"@artsy/eigen-web-association@^1.2.1":
   version "1.2.1"
-  resolved "git://github.com/artsy/artsy-eigen-web-association.git#0589e3d9da9b904a51d4b8c9c39cd8a585428493"
+  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.2.1.tgz#8b286b8fe15384dd53ad85dd90b7c7acf660115b"
+  integrity sha512-o9IWTgo595yKPDLCv3t7MqVsXgx1nLEnFjdBPZjZp2XgzQG7oJrLhi8EImn5rmjth/cR+3KOqgia5pTMQqCdWQ==
   dependencies:
     express "^4.15.0"
 


### PR DESCRIPTION
Noticed that the CI test [run failed](https://app.circleci.com/pipelines/github/artsy/artsy-wwwify/396/workflows/78c8d742-0eab-4715-b7f8-3886cd36eb52/jobs/300?invite=true#step-104-64) with the following:

```
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/artsy/artsy-eigen-web-association.git
Directory: /app
Output:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information
```

It seems github is improving protocol security and this failure is a result of that:

>Final brownout. January 11, 2022
This is the full brownout period where we’ll temporarily stop accepting the deprecated key and signature types, ciphers, and MACs, and the unencrypted Git protocol. This will help clients discover any lingering use of older keys or old URLs.

Looked at how force [pulls this dep in](https://github.com/artsy/force/blob/dcd2e25112bf528c06a1a685ea9e674bf9f448f8/package.json#L88) and made the change to mirror that.

Tested locally and `hokusai test` worked.

```
artsy-wwwify_1  | Test Suites: 1 passed, 1 total
artsy-wwwify_1  | Tests:       6 passed, 6 total
artsy-wwwify_1  | Snapshots:   0 total
artsy-wwwify_1  | Time:        0.859s
artsy-wwwify_1  | Ran all test suites.
hokusai_artsy-wwwify_1 exited with code 0
Aborting on container exit...
Tests Passed
```