### PR TITLE
feat: raise hpa min to 2

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -76,7 +76,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: artsy-wwwify-web
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 3
   targetCPUUtilizationPercentage: 70
 


### PR DESCRIPTION
The [Pingdom alert](https://artsy.slack.com/archives/C0HP61PUJ/p1649728010647449) got me double checking HPA min. It is currently 1.

Let's raise it to 2. The redundancy should prevent the service being taken down by Cluster-Autoscaler eviction of 1 pod (when it wants to scale out a node) which might be what happened here.