### PR TITLE
fix: update deeplink denylist to include google auth callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/artsy/artsy-wwwify",
   "dependencies": {
-    "@artsy/eigen-web-association": "1.2.2",
+    "@artsy/eigen-web-association": "1.3.0",
     "morgan": "1.10.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@artsy/eigen-web-association@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.2.2.tgz#59625f1be37ce5579a249c0215c3db494da0c20d"
-  integrity sha512-n2ZrBELGE46CHgV5XU6akusxunI3W0l8JrQ+YQOPygX2Lw2ZvpzI4I8ug9NbSldDI/4ThPiExdgN+kMkI+4VGA==
+"@artsy/eigen-web-association@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.3.0.tgz#9181452dcdf4a159a2d368ae04e98f850b536f3b"
+  integrity sha512-vRDublbvMdhfFsQrzeUmIHOIFlW12Suq/ZQU83Bp4Faiad0hcQWyDjv4MppD+r2c7Y0gr9YdD4oa9+3TAIMt0A==
   dependencies:
     express "^4.15.0"
 


### PR DESCRIPTION
Updates eigen-web-association dependency to latest version which includes google auth callback in denylist.