### PR TITLE
fix: update web association, add missing auth endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/artsy/artsy-wwwify",
   "dependencies": {
-    "@artsy/eigen-web-association": "1.3.0",
+    "@artsy/eigen-web-association": "1.5.0",
     "morgan": "1.10.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@artsy/eigen-web-association@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.3.0.tgz#9181452dcdf4a159a2d368ae04e98f850b536f3b"
-  integrity sha512-vRDublbvMdhfFsQrzeUmIHOIFlW12Suq/ZQU83Bp4Faiad0hcQWyDjv4MppD+r2c7Y0gr9YdD4oa9+3TAIMt0A==
+"@artsy/eigen-web-association@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@artsy/eigen-web-association/-/eigen-web-association-1.5.0.tgz#6edc462382001906ee6455aa8fed6ba8b987130b"
+  integrity sha512-kIGhH4uSfxSO7XnWXKcXHXpDjxGN76JgvItsADAiPjP1AfyJtIYw+HyZzjt03hcF2sk3uDiElTRhW+1zvLAxtA==
   dependencies:
     express "^4.15.0"
 


### PR DESCRIPTION
update web association with a few more missing auth endpoints to prevent deep linking during auth flows.
future friday idea: monitor changes to auth endpoints and aliases and remind to update the deeplink config. 